### PR TITLE
9-feature-add-verification-for-provider-credentials

### DIFF
--- a/qplex/helpers/factories/solver_factory.py
+++ b/qplex/helpers/factories/solver_factory.py
@@ -3,10 +3,20 @@ from qplex.solvers import DWaveSolver, GateBasedSolver
 
 class SolverFactory:
     @staticmethod
-    def get_solver(backend):
+    def get_solver(backend: str, quantum_api_tokens: dict):
+        if backend is None:
+            if quantum_api_tokens.get("dwave_token"):
+                return DWaveSolver()
+            if quantum_api_tokens.get("ibm_token"):
+                return GateBasedSolver()
+            raise RuntimeError("Missing credentials for quantum provider")
         if backend == 'd-wave':
+            if quantum_api_tokens.get("dwave_token") is None:
+                raise RuntimeError("Missing credentials for the D-Wave provider")
             return DWaveSolver()
         if backend == 'ibm':
+            if quantum_api_tokens.get("ibm_token") is None:
+                raise RuntimeError("Missing credentials for the IBM provider")
             return GateBasedSolver()
         raise ValueError(backend)
 

--- a/qplex/model/qmodel.py
+++ b/qplex/model/qmodel.py
@@ -1,6 +1,7 @@
 from docplex.mp.model import Model
 from docplex.mp.solution import SolveSolution
 from qplex.helpers.factories.solver_factory import solver_factory
+import os
 
 
 class QModel(Model):
@@ -8,6 +9,10 @@ class QModel(Model):
     def __init__(self, name):
         super(QModel, self).__init__(name)
         self.job_id = None
+        self.quantum_api_tokens = {
+            "dwave_token": os.environ.get('DWAVE_API_TOKEN'),
+            "ibm_token": os.environ.get('IBM_API_TOKEN'),
+        }
 
     def build_model_dict(self) -> dict:
         return {
@@ -28,8 +33,9 @@ class QModel(Model):
             Model.solve(self)
         elif solver == 'quantum':
             model = self.build_model_dict()
-            model_solver = solver_factory.get_solver(backend)
-            self.set_solution(model_solver.solve(model))
+            model_solver = solver_factory.get_solver(backend, self.quantum_api_tokens)
+            solution = model_solver.solve(model)
+            self.set_solution(solution)
         else:
             raise ValueError("Invalid value for argument 'solver'")
 

--- a/qplex/solvers/dwave_solver.py
+++ b/qplex/solvers/dwave_solver.py
@@ -2,13 +2,12 @@ from docplex.mp.linear import LinearExpr
 from qplex.model.constants import VAR_TYPE
 from dwave.system import LeapHybridCQMSampler
 from dimod import ConstrainedQuadraticModel, QuadraticModel
-import os
 
 
 class DWaveSolver:
 
     def solve(self, model) -> dict:
-        token = os.environ.get('DWAVE_API_TOKEN')
+        token = model.quantum_api_tokens.get("dwave_token")
         sampler = LeapHybridCQMSampler(token=token)
         cqm = self.parse_model(model)
         sampleset = sampler.sample_cqm(cqm, label=model['name'])


### PR DESCRIPTION
This PR adds a token dictionary containing the different quantum provider API tokens that the user may have added to their environment. This dictionary gets instantiated when a QModel is created, and it is used by the SolverFactory.